### PR TITLE
feat: add instagram-style mobile feed preview page

### DIFF
--- a/job-portal/src/App.css
+++ b/job-portal/src/App.css
@@ -1,40 +1,225 @@
-/* Custom styles for the job portal */
-
-.line-clamp-2 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+:root {
+  --bg: #f5f5f7;
+  --text: #10131a;
+  --muted: #69707d;
+  --card: #ffffff;
 }
 
-.line-clamp-3 {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-}
-
-/* Smooth transitions */
 * {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
+  box-sizing: border-box;
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar {
+.insta-shell {
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  background: linear-gradient(180deg, #eceef5 0%, #f8f9fb 100%);
+  padding: 24px;
+  color: var(--text);
+}
+
+.phone-frame {
+  width: min(100%, 420px);
+  background: var(--card);
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(5, 12, 30, 0.2);
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 18px;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.battery {
+  background: #111;
+  color: #fff;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 0.95rem;
+}
+
+.story-strip {
+  display: flex;
+  overflow-x: auto;
+  gap: 16px;
+  padding: 10px 16px 18px;
+  border-bottom: 1px solid #eceff4;
+}
+
+.story-item {
+  min-width: 78px;
+  text-align: center;
+  font-size: 0.92rem;
+}
+
+.story-ring {
+  width: 74px;
+  height: 74px;
+  padding: 3px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, #feda75, #fa7e1e, #d62976, #962fbf);
+  margin: 0 auto 8px;
+  position: relative;
+}
+
+.story-ring img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #fff;
+}
+
+.story-plus {
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #1d9bf0;
+  color: #fff;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  border: 2px solid #fff;
+}
+
+.post-card {
+  background: var(--card);
+}
+
+.post-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+}
+
+.author-wrap {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.author-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: #8cc6eb;
+  display: grid;
+  place-items: center;
+  font-size: 0.82rem;
+}
+
+.post-media {
+  position: relative;
+  background: #000;
+}
+
+.post-media img {
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+  opacity: 0.82;
+}
+
+.mute-btn {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  border: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+}
+
+.media-caption {
+  position: absolute;
+  bottom: 26px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  color: #fff;
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+.post-dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+}
+
+.post-dots span {
   width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d5dbe6;
 }
 
-::-webkit-scrollbar-track {
-  background: #f1f5f9;
+.post-dots .active {
+  background: #4f6cf3;
 }
 
-::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 4px;
+.post-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  font-size: 1.1rem;
 }
 
-::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
+.post-actions > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bookmark {
+  margin-left: auto;
+}
+
+.post-text {
+  margin: 6px 16px;
+  font-size: 1.38rem;
+  line-height: 1.35;
+}
+
+.post-time {
+  color: var(--muted);
+  margin: 0 16px 16px;
+  display: block;
+  font-size: 1.05rem;
+}
+
+.bottom-nav {
+  border-top: 1px solid #eef2f7;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  padding: 12px 10px 18px;
+  font-size: 2rem;
+}
+
+@media (max-width: 520px) {
+  .insta-shell {
+    padding: 0;
+    background: #fff;
+  }
+
+  .phone-frame {
+    border-radius: 0;
+    box-shadow: none;
+    width: 100%;
+  }
 }

--- a/job-portal/src/App.test.tsx
+++ b/job-portal/src/App.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders instagram style preview content', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getAllByText('ai.favmag').length).toBeGreaterThan(0);
+  expect(screen.getByText('내 스토리')).toBeInTheDocument();
+  expect(screen.getByText('AI Fav Mag')).toBeInTheDocument();
 });

--- a/job-portal/src/App.tsx
+++ b/job-portal/src/App.tsx
@@ -1,49 +1,104 @@
-import React, { useState } from 'react';
-import Layout from './components/Layout';
-import JobListPage from './pages/JobListPage';
-import JobDetailPage from './pages/JobDetailPage';
-import { AuthProvider } from './context/AuthContext';
-import { Job } from './types';
+import React from 'react';
+import {
+  Bookmark,
+  CircleUserRound,
+  Ellipsis,
+  Heart,
+  Home,
+  MessageCircle,
+  Navigation,
+  PlaySquare,
+  Repeat,
+  Search,
+  Volume2,
+} from 'lucide-react';
+
+type Story = {
+  id: number;
+  name: string;
+  image: string;
+  mine?: boolean;
+};
+
+const stories: Story[] = [
+  { id: 1, name: '내 스토리', image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=200&h=200&fit=crop', mine: true },
+  { id: 2, name: 'timberwolves', image: 'https://images.unsplash.com/photo-1517649763962-0c623066013b?w=200&h=200&fit=crop' },
+  { id: 3, name: 'magicjohnson', image: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=200&h=200&fit=crop' },
+  { id: 4, name: 'shams', image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop' },
+];
 
 function App() {
-  const [currentPage, setCurrentPage] = useState<'list' | 'detail'>('list');
-  const [selectedJob, setSelectedJob] = useState<Job | null>(null);
-  const [searchQuery, setSearchQuery] = useState<string>('');
-
-  const handleJobSelect = (job: Job) => {
-    setSelectedJob(job);
-    setCurrentPage('detail');
-  };
-
-  const handleBackToList = () => {
-    setCurrentPage('list');
-    setSelectedJob(null);
-  };
-
-  const handleSearch = (query: string) => {
-    setSearchQuery(query);
-    if (currentPage !== 'list') {
-      setCurrentPage('list');
-    }
-  };
-
   return (
-    <AuthProvider>
-      <Layout onSearch={handleSearch}>
-        {currentPage === 'list' && (
-          <JobListPage 
-            searchQuery={searchQuery}
-            onJobSelect={handleJobSelect}
-          />
-        )}
-        {currentPage === 'detail' && selectedJob && (
-          <JobDetailPage 
-            job={selectedJob}
-            onBack={handleBackToList}
-          />
-        )}
-      </Layout>
-    </AuthProvider>
+    <div className="insta-shell">
+      <div className="phone-frame">
+        <header className="status-bar">
+          <span>8:44</span>
+          <span className="battery">68</span>
+        </header>
+
+        <section className="story-strip" aria-label="스토리 목록">
+          {stories.map((story) => (
+            <div key={story.id} className="story-item">
+              <div className="story-ring">
+                <img src={story.image} alt={story.name} />
+                {story.mine && <span className="story-plus">+</span>}
+              </div>
+              <span>{story.name}</span>
+            </div>
+          ))}
+        </section>
+
+        <article className="post-card" aria-label="인스타그램 게시글 미리보기">
+          <div className="post-header">
+            <div className="author-wrap">
+              <div className="author-avatar">AF</div>
+              <strong>ai.favmag</strong>
+            </div>
+            <Ellipsis size={24} />
+          </div>
+
+          <div className="post-media">
+            <img
+              src="https://images.unsplash.com/photo-1526378722484-bd91ca387e72?w=1200&h=1600&fit=crop"
+              alt="AI 미디어 아트 인터랙션 장면"
+            />
+            <button className="mute-btn" aria-label="음소거 토글">
+              <Volume2 size={22} />
+            </button>
+            <div className="media-caption">AI Fav Mag</div>
+          </div>
+
+          <div className="post-dots" aria-hidden="true">
+            <span />
+            <span />
+            <span className="active" />
+            <span />
+            <span />
+          </div>
+
+          <div className="post-actions">
+            <div><Heart /> 1,552</div>
+            <div><MessageCircle /> 377</div>
+            <div><Repeat /> 106</div>
+            <div><Navigation /> 899</div>
+            <Bookmark className="bookmark" />
+          </div>
+
+          <p className="post-text">
+            <strong>ai.favmag</strong> 코딩 없이 인터랙티브 미디어 아트가 만들어지는 워크플로우를 소개합니다.
+          </p>
+          <span className="post-time">4일 전</span>
+        </article>
+
+        <nav className="bottom-nav" aria-label="하단 네비게이션">
+          <Home />
+          <PlaySquare />
+          <Navigation />
+          <Search />
+          <CircleUserRound />
+        </nav>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
### Motivation
- Provide a quick, mobile-first UI prototype matching the reference screenshot to test layout and visual behavior in the site.
- Replace the previous job-portal app shell with a focused static preview so the page can be iterated against the image.

### Description
- Replaced the main app with an Instagram-style feed prototype by updating `job-portal/src/App.tsx` to render a story strip, a post card (header, media, actions, caption) and a bottom navigation using `lucide-react` icons.
- Rewrote styling in `job-portal/src/App.css` to implement the phone frame, gradient story rings, media area, dot indicators, action row and responsive behavior.
- Updated `job-portal/src/App.test.tsx` to assert on the new UI content and changed a strict `getByText('ai.favmag')` to `getAllByText('ai.favmag')` (or assert count) to accommodate repeated text nodes rendered in the prototype.

### Testing
- Ran unit tests with `npm test -- --watchAll=false` and the updated test passed (`1 passed`).
- Attempted production build with `npm run build` and it failed due to the repository's Tailwind/PostCSS plugin configuration (`tailwindcss` used directly as a PostCSS plugin) and missing `@tailwindcss/postcss` integration, so the build did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5a60607c832cbdc56f9f9ec2b47b)