### PR TITLE
feat: add simple notion-style memo app UI and interactions

### DIFF
--- a/job-portal/src/App.css
+++ b/job-portal/src/App.css
@@ -1,225 +1,230 @@
 :root {
-  --bg: #f5f5f7;
-  --text: #10131a;
-  --muted: #69707d;
-  --card: #ffffff;
+  --bg: #f3f4f8;
+  --panel: #ffffff;
+  --panel-sub: #f7f8fc;
+  --text: #191b23;
+  --muted: #7a8092;
+  --line: #e6e8f0;
+  --accent: #6366f1;
 }
 
 * {
   box-sizing: border-box;
 }
 
-.insta-shell {
+.notes-shell {
   min-height: 100vh;
-  margin: 0;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  background: linear-gradient(180deg, #eceef5 0%, #f8f9fb 100%);
+  background: radial-gradient(circle at top right, #eceffe, #f5f6fb 46%, #f1f2f7 100%);
   padding: 24px;
+}
+
+.notes-window {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  background: var(--panel);
+  border-radius: 28px;
+  border: 1px solid #ebedf4;
+  box-shadow: 0 18px 45px rgba(39, 41, 63, 0.12);
+  display: grid;
+  grid-template-columns: 330px 1fr;
+  min-height: calc(100vh - 48px);
+  overflow: hidden;
+}
+
+.sidebar {
+  padding: 22px 16px;
+  border-right: 1px solid var(--line);
+  background: var(--panel-sub);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.brand-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 4px;
+}
+
+.brand-row h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  letter-spacing: -0.02em;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px 12px;
+  color: var(--muted);
+}
+
+.search-box input {
+  border: 0;
+  background: transparent;
+  width: 100%;
+  font-size: 0.95rem;
+  color: var(--text);
+  outline: none;
+}
+
+.note-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.note-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: #fff;
+  padding: 12px;
+  cursor: pointer;
   color: var(--text);
 }
 
-.phone-frame {
-  width: min(100%, 420px);
-  background: var(--card);
-  border-radius: 28px;
-  overflow: hidden;
-  box-shadow: 0 20px 60px rgba(5, 12, 30, 0.2);
+.note-item.active {
+  border-color: rgba(99, 102, 241, 0.5);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
 }
 
-.status-bar {
+.note-item-title-row {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  padding: 16px 18px;
-  font-size: 1.05rem;
-  font-weight: 700;
+  gap: 10px;
+  margin-bottom: 6px;
 }
 
-.battery {
-  background: #111;
-  color: #fff;
-  border-radius: 999px;
-  padding: 2px 8px;
+.note-item strong {
   font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.story-strip {
+.note-item p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #4a5160;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  min-height: 2.5em;
+}
+
+.note-item span {
+  margin-top: 8px;
+  display: block;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.editor {
   display: flex;
-  overflow-x: auto;
-  gap: 16px;
-  padding: 10px 16px 18px;
-  border-bottom: 1px solid #eceff4;
+  flex-direction: column;
+  padding: 24px;
+  gap: 14px;
 }
 
-.story-item {
-  min-width: 78px;
-  text-align: center;
-  font-size: 0.92rem;
+.editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
-.story-ring {
-  width: 74px;
-  height: 74px;
-  padding: 3px;
-  border-radius: 50%;
-  background: linear-gradient(45deg, #feda75, #fa7e1e, #d62976, #962fbf);
-  margin: 0 auto 8px;
-  position: relative;
+.icon-btn {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--text);
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
 }
 
-.story-ring img {
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 3px solid #fff;
+.icon-btn.primary {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  justify-content: center;
+  border-color: #c9ccff;
+  color: var(--accent);
 }
 
-.story-plus {
-  position: absolute;
-  right: -3px;
-  bottom: -3px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: #1d9bf0;
-  color: #fff;
+.icon-btn.danger {
+  color: #d8374d;
+  border-color: #ffd3da;
+}
+
+.title-input {
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  padding: 10px 0;
+  font-size: 1.6rem;
   font-weight: 700;
+  outline: none;
+}
+
+.content-input {
+  flex: 1;
+  border: 0;
+  resize: none;
+  font-size: 1.02rem;
+  line-height: 1.7;
+  outline: none;
+}
+
+.editor-footer {
+  color: var(--muted);
+  font-size: 0.84rem;
+  border-top: 1px dashed var(--line);
+  padding-top: 10px;
+}
+
+.empty-list {
+  color: var(--muted);
+  text-align: center;
+  margin: 24px 0;
+}
+
+.empty-state {
+  flex: 1;
   display: grid;
-  place-items: center;
-  border: 2px solid #fff;
-}
-
-.post-card {
-  background: var(--card);
-}
-
-.post-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-}
-
-.author-wrap {
-  display: flex;
-  align-items: center;
+  place-content: center;
+  color: var(--muted);
+  text-align: center;
   gap: 12px;
 }
 
-.author-avatar {
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  background: #8cc6eb;
-  display: grid;
-  place-items: center;
-  font-size: 0.82rem;
-}
-
-.post-media {
-  position: relative;
-  background: #000;
-}
-
-.post-media img {
-  width: 100%;
-  aspect-ratio: 4 / 5;
-  object-fit: cover;
-  opacity: 0.82;
-}
-
-.mute-btn {
-  position: absolute;
-  right: 16px;
-  bottom: 16px;
-  border: none;
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
-}
-
-.media-caption {
-  position: absolute;
-  bottom: 26px;
-  left: 0;
-  width: 100%;
-  text-align: center;
-  color: #fff;
-  font-size: 1.25rem;
-  font-weight: 500;
-}
-
-.post-dots {
-  display: flex;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px;
-}
-
-.post-dots span {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #d5dbe6;
-}
-
-.post-dots .active {
-  background: #4f6cf3;
-}
-
-.post-actions {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 6px 16px;
-  font-size: 1.1rem;
-}
-
-.post-actions > div {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.bookmark {
-  margin-left: auto;
-}
-
-.post-text {
-  margin: 6px 16px;
-  font-size: 1.38rem;
-  line-height: 1.35;
-}
-
-.post-time {
-  color: var(--muted);
-  margin: 0 16px 16px;
-  display: block;
-  font-size: 1.05rem;
-}
-
-.bottom-nav {
-  border-top: 1px solid #eef2f7;
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  padding: 12px 10px 18px;
-  font-size: 2rem;
-}
-
-@media (max-width: 520px) {
-  .insta-shell {
+@media (max-width: 860px) {
+  .notes-shell {
     padding: 0;
-    background: #fff;
   }
 
-  .phone-frame {
+  .notes-window {
     border-radius: 0;
-    box-shadow: none;
-    width: 100%;
+    grid-template-columns: 1fr;
+    min-height: 100vh;
+  }
+
+  .sidebar {
+    max-height: 42vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
   }
 }

--- a/job-portal/src/App.test.tsx
+++ b/job-portal/src/App.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders instagram style preview content', () => {
+test('renders notes app and can create a new note', () => {
   render(<App />);
-  expect(screen.getAllByText('ai.favmag').length).toBeGreaterThan(0);
-  expect(screen.getByText('내 스토리')).toBeInTheDocument();
-  expect(screen.getByText('AI Fav Mag')).toBeInTheDocument();
+
+  expect(screen.getByRole('heading', { name: '메모' })).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('메모 검색')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: '새 메모 생성' }));
+
+  expect(screen.getByDisplayValue('새 메모')).toBeInTheDocument();
+  expect(screen.getByPlaceholderText('여기에 메모를 작성하세요')).toBeInTheDocument();
 });

--- a/job-portal/src/App.tsx
+++ b/job-portal/src/App.tsx
@@ -1,102 +1,221 @@
-import React from 'react';
-import {
-  Bookmark,
-  CircleUserRound,
-  Ellipsis,
-  Heart,
-  Home,
-  MessageCircle,
-  Navigation,
-  PlaySquare,
-  Repeat,
-  Search,
-  Volume2,
-} from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Plus, Search, Pin, PinOff, Trash2, FileText } from 'lucide-react';
 
-type Story = {
-  id: number;
-  name: string;
-  image: string;
-  mine?: boolean;
+type Note = {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+  pinned: boolean;
 };
 
-const stories: Story[] = [
-  { id: 1, name: '내 스토리', image: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=200&h=200&fit=crop', mine: true },
-  { id: 2, name: 'timberwolves', image: 'https://images.unsplash.com/photo-1517649763962-0c623066013b?w=200&h=200&fit=crop' },
-  { id: 3, name: 'magicjohnson', image: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=200&h=200&fit=crop' },
-  { id: 4, name: 'shams', image: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop' },
-];
+const STORAGE_KEY = 'simple-notes-v1';
+
+const createId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const createNewNote = (): Note => {
+  const now = new Date().toISOString();
+  return {
+    id: createId(),
+    title: '새 메모',
+    content: '',
+    updatedAt: now,
+    pinned: false,
+  };
+};
+
+const formatKoreanDate = (iso: string): string => {
+  const date = new Date(iso);
+  return new Intl.DateTimeFormat('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+};
 
 function App() {
+  const [notes, setNotes] = useState<Note[]>(() => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) {
+      return [
+        {
+          id: createId(),
+          title: '오늘 아이디어',
+          content: '심플한 메모앱 느낌\n- 할 일 정리\n- 떠오른 생각 기록\n- 빠르게 검색',
+          updatedAt: new Date().toISOString(),
+          pinned: true,
+        },
+      ];
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as Note[];
+      return parsed;
+    } catch {
+      return [];
+    }
+  });
+
+  const [selectedId, setSelectedId] = useState<string>(() => notes[0]?.id ?? '');
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+  }, [notes]);
+
+  const filteredNotes = useMemo(() => {
+    const search = query.trim().toLowerCase();
+
+    return [...notes]
+      .sort((a, b) => {
+        if (a.pinned === b.pinned) {
+          return b.updatedAt.localeCompare(a.updatedAt);
+        }
+        return a.pinned ? -1 : 1;
+      })
+      .filter((note) => {
+        if (!search) {
+          return true;
+        }
+
+        return (
+          note.title.toLowerCase().includes(search) ||
+          note.content.toLowerCase().includes(search)
+        );
+      });
+  }, [notes, query]);
+
+  useEffect(() => {
+    if (!selectedId && filteredNotes[0]) {
+      setSelectedId(filteredNotes[0].id);
+    }
+  }, [filteredNotes, selectedId]);
+
+  const selectedNote = notes.find((note) => note.id === selectedId);
+
+  const updateSelectedNote = (next: Partial<Note>) => {
+    if (!selectedNote) {
+      return;
+    }
+
+    const updatedAt = new Date().toISOString();
+    setNotes((prev) =>
+      prev.map((note) =>
+        note.id === selectedNote.id
+          ? { ...note, ...next, updatedAt: next.updatedAt ?? updatedAt }
+          : note,
+      ),
+    );
+  };
+
+  const handleAddNote = () => {
+    const newNote = createNewNote();
+    setNotes((prev) => [newNote, ...prev]);
+    setSelectedId(newNote.id);
+    setQuery('');
+  };
+
+  const handleDeleteNote = () => {
+    if (!selectedNote) {
+      return;
+    }
+
+    setNotes((prev) => prev.filter((note) => note.id !== selectedNote.id));
+
+    const remaining = notes.filter((note) => note.id !== selectedNote.id);
+    setSelectedId(remaining[0]?.id ?? '');
+  };
+
   return (
-    <div className="insta-shell">
-      <div className="phone-frame">
-        <header className="status-bar">
-          <span>8:44</span>
-          <span className="battery">68</span>
-        </header>
-
-        <section className="story-strip" aria-label="스토리 목록">
-          {stories.map((story) => (
-            <div key={story.id} className="story-item">
-              <div className="story-ring">
-                <img src={story.image} alt={story.name} />
-                {story.mine && <span className="story-plus">+</span>}
-              </div>
-              <span>{story.name}</span>
-            </div>
-          ))}
-        </section>
-
-        <article className="post-card" aria-label="인스타그램 게시글 미리보기">
-          <div className="post-header">
-            <div className="author-wrap">
-              <div className="author-avatar">AF</div>
-              <strong>ai.favmag</strong>
-            </div>
-            <Ellipsis size={24} />
-          </div>
-
-          <div className="post-media">
-            <img
-              src="https://images.unsplash.com/photo-1526378722484-bd91ca387e72?w=1200&h=1600&fit=crop"
-              alt="AI 미디어 아트 인터랙션 장면"
-            />
-            <button className="mute-btn" aria-label="음소거 토글">
-              <Volume2 size={22} />
+    <div className="notes-shell">
+      <div className="notes-window">
+        <aside className="sidebar">
+          <div className="brand-row">
+            <h1>메모</h1>
+            <button type="button" className="icon-btn primary" onClick={handleAddNote} aria-label="새 메모 생성">
+              <Plus size={18} />
             </button>
-            <div className="media-caption">AI Fav Mag</div>
           </div>
 
-          <div className="post-dots" aria-hidden="true">
-            <span />
-            <span />
-            <span className="active" />
-            <span />
-            <span />
+          <label className="search-box" htmlFor="note-search">
+            <Search size={16} />
+            <input
+              id="note-search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="메모 검색"
+            />
+          </label>
+
+          <div className="note-list" aria-label="메모 목록">
+            {filteredNotes.length === 0 && <p className="empty-list">검색 결과가 없어요.</p>}
+
+            {filteredNotes.map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                className={`note-item ${note.id === selectedId ? 'active' : ''}`}
+                onClick={() => setSelectedId(note.id)}
+              >
+                <div className="note-item-title-row">
+                  <strong>{note.title || '제목 없음'}</strong>
+                  {note.pinned && <Pin size={14} />}
+                </div>
+                <p>{note.content || '내용 없음'}</p>
+                <span>{formatKoreanDate(note.updatedAt)}</span>
+              </button>
+            ))}
           </div>
+        </aside>
 
-          <div className="post-actions">
-            <div><Heart /> 1,552</div>
-            <div><MessageCircle /> 377</div>
-            <div><Repeat /> 106</div>
-            <div><Navigation /> 899</div>
-            <Bookmark className="bookmark" />
-          </div>
+        <main className="editor">
+          {selectedNote ? (
+            <>
+              <div className="editor-actions">
+                <button
+                  type="button"
+                  className="icon-btn"
+                  onClick={() => updateSelectedNote({ pinned: !selectedNote.pinned })}
+                >
+                  {selectedNote.pinned ? <PinOff size={16} /> : <Pin size={16} />}
+                  {selectedNote.pinned ? '고정 해제' : '상단 고정'}
+                </button>
 
-          <p className="post-text">
-            <strong>ai.favmag</strong> 코딩 없이 인터랙티브 미디어 아트가 만들어지는 워크플로우를 소개합니다.
-          </p>
-          <span className="post-time">4일 전</span>
-        </article>
+                <button type="button" className="icon-btn danger" onClick={handleDeleteNote}>
+                  <Trash2 size={16} /> 삭제
+                </button>
+              </div>
 
-        <nav className="bottom-nav" aria-label="하단 네비게이션">
-          <Home />
-          <PlaySquare />
-          <Navigation />
-          <Search />
-          <CircleUserRound />
-        </nav>
+              <input
+                className="title-input"
+                value={selectedNote.title}
+                onChange={(event) => updateSelectedNote({ title: event.target.value })}
+                placeholder="제목"
+              />
+
+              <textarea
+                className="content-input"
+                value={selectedNote.content}
+                onChange={(event) => updateSelectedNote({ content: event.target.value })}
+                placeholder="여기에 메모를 작성하세요"
+              />
+
+              <footer className="editor-footer">최근 수정: {formatKoreanDate(selectedNote.updatedAt)}</footer>
+            </>
+          ) : (
+            <div className="empty-state">
+              <FileText size={40} />
+              <p>왼쪽 + 버튼으로 첫 메모를 만들어보세요.</p>
+            </div>
+          )}
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Provide a small, clean memo app (Notion-like + iPhone Notes feel) to replace the previous social-preview UI and satisfy the request for a simple note-taking site.
- Make the app usable in browser and tests, including handling environments without `crypto.randomUUID()`.

### Description
- Replaced the previous Instagram-style preview with a two-pane memo app and interactions in `job-portal/src/App.tsx` (note model, creation, selection, inline edit, pin/unpin, delete, search, and `localStorage` persistence). 
- Added `createId()` fallback for environments where `crypto.randomUUID()` is not available and a `formatKoreanDate()` helper for timestamps.
- Rewrote layout and styles in `job-portal/src/App.css` to a responsive two-column notes UI (sidebar + editor) and mobile behavior.
- Updated `job-portal/src/App.test.tsx` to exercise memo app rendering and the new note creation flow.

### Testing
- Ran `npm test -- --watchAll=false` (the updated unit test `src/App.test.tsx` passed). ✅
- Ran `npm run build` which failed due to the existing Tailwind/PostCSS configuration requiring `@tailwindcss/postcss`, so production build did not complete. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc21c9428832ca79cf011912dd6b7)