### PR TITLE
feat: add Flutter memo link app with Supabase-backed note sharing

### DIFF
--- a/memo_link_app/.env.example
+++ b/memo_link_app/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+SUPABASE_ANON_KEY=YOUR_ANON_KEY
+APP_BASE_URL=https://yourapp.com

--- a/memo_link_app/README.md
+++ b/memo_link_app/README.md
@@ -1,0 +1,33 @@
+# Memo Link App (Flutter + Supabase)
+
+링크 기반 메모 공유 앱입니다. Android/macOS 실행을 목표로 했습니다.
+
+## 1) 시작하기
+
+```bash
+cp .env.example .env
+# .env에 Supabase 정보 입력
+flutter pub get
+flutter run
+```
+
+## 2) Supabase 준비
+
+1. Supabase 프로젝트 생성
+2. `supabase/schema.sql` 실행
+3. `.env`에 아래 값 설정
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - `APP_BASE_URL` (예: `https://yourapp.com`)
+
+## 3) 라우팅
+
+- 홈: `/`
+- 메모 조회: `/n/{short_id}`
+
+## 4) 포함 기능
+
+- 메모 작성 (최대 10,000자)
+- 저장 후 short link 생성
+- 링크/내용 복사
+- short_id 기반 조회 (읽기 전용)

--- a/memo_link_app/README.md
+++ b/memo_link_app/README.md
@@ -1,6 +1,6 @@
 # Memo Link App (Flutter + Supabase)
 
-링크 기반 메모 공유 앱입니다. Android/macOS 실행을 목표로 했습니다.
+링크 기반 메모 공유 앱입니다. Android/macOS 실행을 목표로 했고, Flutter Web로 배포하면 브라우저에서도 동일하게 볼 수 있습니다.
 
 ## 1) 시작하기
 
@@ -31,3 +31,26 @@ flutter run
 - 저장 후 short link 생성
 - 링크/내용 복사
 - short_id 기반 조회 (읽기 전용)
+
+## 5) Vercel 배포 시 404 해결 (중요)
+
+`/n/abc123` 같은 직접 URL 접근 시 Vercel이 서버에서 파일을 찾으려다 404를 낼 수 있습니다.
+Flutter Web SPA 라우팅이 동작하도록 `vercel.json`의 rewrite 설정이 필요합니다.
+
+이 저장소에는 아래 설정이 이미 포함되어 있습니다.
+
+- `vercel.json`: 모든 경로를 `/index.html`로 rewrite
+
+### 배포 순서
+
+```bash
+flutter build web
+```
+
+Vercel 프로젝트 설정:
+1. **Root Directory**를 `memo_link_app`로 지정
+2. **Build Command**: `flutter build web`
+3. **Output Directory**: `build/web`
+4. `vercel.json`이 루트(`memo_link_app/vercel.json`)에 있는지 확인
+
+> 만약 Root Directory를 잘못 지정하면 rewrite가 적용되지 않아 404가 계속 발생합니다.

--- a/memo_link_app/lib/main.dart
+++ b/memo_link_app/lib/main.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'screens/home_screen.dart';
+import 'screens/view_screen.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
+
+  await Supabase.initialize(
+    url: dotenv.env['SUPABASE_URL'] ?? '',
+    anonKey: dotenv.env['SUPABASE_ANON_KEY'] ?? '',
+  );
+
+  runApp(const ProviderScope(child: MemoLinkApp()));
+}
+
+class MemoLinkApp extends StatelessWidget {
+  const MemoLinkApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Memo Link',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      ),
+      home: const HomeScreen(),
+      onGenerateRoute: (settings) {
+        final routeName = settings.name ?? '/';
+        final segments = Uri.parse(routeName).pathSegments;
+
+        if (segments.length == 2 && segments.first == 'n') {
+          return MaterialPageRoute<void>(
+            builder: (_) => ViewScreen(shortId: segments[1]),
+          );
+        }
+
+        return MaterialPageRoute<void>(builder: (_) => const HomeScreen());
+      },
+    );
+  }
+}

--- a/memo_link_app/lib/models/note.dart
+++ b/memo_link_app/lib/models/note.dart
@@ -1,0 +1,27 @@
+class Note {
+  final String id;
+  final String shortId;
+  final String content;
+  final DateTime createdAt;
+  final DateTime? expiresAt;
+
+  const Note({
+    required this.id,
+    required this.shortId,
+    required this.content,
+    required this.createdAt,
+    this.expiresAt,
+  });
+
+  factory Note.fromJson(Map<String, dynamic> json) {
+    return Note(
+      id: json['id'] as String,
+      shortId: json['short_id'] as String,
+      content: json['content'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      expiresAt: json['expires_at'] == null
+          ? null
+          : DateTime.parse(json['expires_at'] as String),
+    );
+  }
+}

--- a/memo_link_app/lib/screens/home_screen.dart
+++ b/memo_link_app/lib/screens/home_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/api_service.dart';
+import 'result_screen.dart';
+
+final apiServiceProvider = Provider<ApiService>((ref) => ApiService());
+
+class HomeScreen extends ConsumerStatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  final _controller = TextEditingController();
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveNote() async {
+    setState(() => _isSaving = true);
+    try {
+      final api = ref.read(apiServiceProvider);
+      final (shortId, url) = await api.createNote(_controller.text);
+
+      if (!mounted) return;
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => ResultScreen(shortId: shortId, url: url),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('저장 실패: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('메모 작성')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                maxLines: null,
+                expands: true,
+                maxLength: 10000,
+                textAlignVertical: TextAlignVertical.top,
+                decoration: const InputDecoration(
+                  hintText: '메모를 입력하세요',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _isSaving ? null : _saveNote,
+                child: Text(_isSaving ? '저장 중...' : '저장하기'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/memo_link_app/lib/screens/result_screen.dart
+++ b/memo_link_app/lib/screens/result_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ResultScreen extends StatelessWidget {
+  const ResultScreen({super.key, required this.shortId, required this.url});
+
+  final String shortId;
+  final String url;
+
+  Future<void> _copyToClipboard(BuildContext context) async {
+    await Clipboard.setData(ClipboardData(text: url));
+    if (!context.mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('링크가 복사되었습니다.')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('링크 생성 완료')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('short_id: $shortId', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            SelectableText(url, style: Theme.of(context).textTheme.bodyLarge),
+            const SizedBox(height: 20),
+            FilledButton.icon(
+              onPressed: () => _copyToClipboard(context),
+              icon: const Icon(Icons.copy),
+              label: const Text('복사하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/memo_link_app/lib/screens/view_screen.dart
+++ b/memo_link_app/lib/screens/view_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../models/note.dart';
+import 'home_screen.dart';
+
+final noteProvider = FutureProvider.family<Note, String>((ref, shortId) async {
+  final api = ref.read(apiServiceProvider);
+  return api.getNoteByShortId(shortId);
+});
+
+class ViewScreen extends ConsumerWidget {
+  const ViewScreen({super.key, required this.shortId});
+
+  final String shortId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncNote = ref.watch(noteProvider(shortId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('메모 보기')),
+      body: asyncNote.when(
+        data: (note) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('생성일: ${DateFormat('yyyy-MM-dd HH:mm').format(note.createdAt.toLocal())}'),
+              const SizedBox(height: 12),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    note.content,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: () async {
+                  await Clipboard.setData(ClipboardData(text: note.content));
+                  if (!context.mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('메모를 복사했습니다.')),
+                  );
+                },
+                icon: const Icon(Icons.copy),
+                label: const Text('복사하기'),
+              ),
+            ],
+          ),
+        ),
+        error: (error, _) => Center(
+          child: Text('오류: $error'),
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}

--- a/memo_link_app/lib/services/api_service.dart
+++ b/memo_link_app/lib/services/api_service.dart
@@ -1,0 +1,61 @@
+import 'dart:math';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/note.dart';
+
+class ApiService {
+  ApiService({SupabaseClient? client})
+      : _client = client ?? Supabase.instance.client;
+
+  final SupabaseClient _client;
+  static const _uuid = Uuid();
+  static const _alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+  Future<(String shortId, String url)> createNote(String content) async {
+    final safeContent = content.trim();
+    if (safeContent.isEmpty) {
+      throw Exception('메모 내용이 비어 있습니다.');
+    }
+    if (safeContent.length > 10000) {
+      throw Exception('메모는 10,000자 이하여야 합니다.');
+    }
+
+    final shortId = _generateShortId();
+
+    await _client.from('notes').insert({
+      'id': _uuid.v4(),
+      'content': safeContent,
+      'short_id': shortId,
+    });
+
+    final baseUrl = (dotenv.env['APP_BASE_URL'] ?? '').trim();
+    final appBaseUrl = baseUrl.isEmpty ? 'https://yourapp.com' : baseUrl;
+
+    return (shortId, '$appBaseUrl/n/$shortId');
+  }
+
+  Future<Note> getNoteByShortId(String shortId) async {
+    final response = await _client
+        .from('notes')
+        .select()
+        .eq('short_id', shortId)
+        .maybeSingle();
+
+    if (response == null) {
+      throw Exception('해당 메모를 찾을 수 없습니다.');
+    }
+
+    return Note.fromJson(response);
+  }
+
+  String _generateShortId() {
+    final random = Random.secure();
+    return List.generate(
+      6,
+      (_) => _alphabet[random.nextInt(_alphabet.length)],
+    ).join();
+  }
+}

--- a/memo_link_app/pubspec.yaml
+++ b/memo_link_app/pubspec.yaml
@@ -1,0 +1,26 @@
+name: memo_link_app
+description: Link-based memo sharing app for Android and macOS
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.6.1
+  supabase_flutter: ^2.8.4
+  uuid: ^4.5.1
+  flutter_dotenv: ^5.2.1
+  intl: ^0.20.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^5.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - .env

--- a/memo_link_app/supabase/schema.sql
+++ b/memo_link_app/supabase/schema.sql
@@ -1,0 +1,19 @@
+create table if not exists public.notes (
+  id uuid primary key,
+  content text not null check (char_length(content) <= 10000),
+  short_id varchar(12) unique not null,
+  created_at timestamp with time zone default now() not null,
+  expires_at timestamp with time zone
+);
+
+create index if not exists notes_short_id_idx on public.notes(short_id);
+
+alter table public.notes enable row level security;
+
+create policy "Allow public insert" on public.notes
+for insert
+with check (true);
+
+create policy "Allow public read" on public.notes
+for select
+using (true);

--- a/memo_link_app/vercel.json
+++ b/memo_link_app/vercel.json
@@ -1,0 +1,19 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Flutter app to create short-link shareable memos and view them via `https://.../n/{short_id}` backed by Supabase. 
- Include platform targets (Android/macOS), environment-driven configuration, and DB schema with sensible RLS policies for public insert/read.

### Description
- Add a new Flutter app scaffold under `memo_link_app/` with entrypoint `lib/main.dart` that loads `.env` and initializes Supabase and route handling for `/n/{short_id}`. 
- Implement `ApiService` (`lib/services/api_service.dart`) with `createNote` and `getNoteByShortId`, including input validation, 6-char short id generation, and Supabase inserts/selects. 
- Add `Note` model (`lib/models/note.dart`) and three screens: `HomeScreen` (`lib/screens/home_screen.dart`) for input, `ResultScreen` (`lib/screens/result_screen.dart`) for showing the generated link, and `ViewScreen` (`lib/screens/view_screen.dart`) for read-only display. 
- Add `pubspec.yaml`, `.env.example`, `README.md`, and Supabase SQL schema `supabase/schema.sql` (table, index, RLS and public insert/read policies). 

### Testing
- Ran `flutter --version` in this environment and it failed because the Flutter SDK is not installed. 
- Ran `dart --version` in this environment and it failed because the Dart SDK is not installed. 
- No automated unit or integration tests were executed in this environment; basic file creation and a git commit were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed80e5fce8832c87f960ca3a1116b2)