### PR TITLE
Create Michael Jordan SNS-style fan site experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,32 +1,23 @@
-# MemoSaaS (Next.js + Supabase)
+# Jordan Legacy (Next.js)
 
-온라인 메모 공유 서비스 SaaS 예제입니다.
+마이클 조던 팬 아카이브/SNS 콘셉트의 학습용 웹사이트입니다.
 
-## 기능
+## 포함된 섹션
 
-- 비회원 메모 작성/저장 후 `/n/{short_id}` 링크 생성
-- 메모 조회 페이지(읽기 전용)
-- 로그인/회원가입(Supabase Auth)
-- 대시보드: 내 메모 목록, 수정, 삭제
-- 요금제: Free(하루 10개) / Pro(무제한, 만료일, 비공개)
-- 보안: 길이 제한, 스크립트 제거, API rate limit, Supabase RLS
+- Hero (Jordan Legacy)
+- Career Timeline
+- Gallery
+- Quotes
+- Free Board (닉네임 기반, 로그인 없음 / localStorage 저장)
 
-## 시작하기
+## 실행
 
 ```bash
-cp .env.example .env.local
 npm install
 npm run dev
 ```
 
-`NEXT_PUBLIC_BASE_URL`을 사용하는 경우 `.env.local`에 추가하세요.
+## 참고
 
-## 필수 환경변수
-
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- `SUPABASE_SERVICE_ROLE_KEY`
-
-## Supabase SQL
-
-`supabase/schema.sql`을 SQL Editor에서 실행하세요.
+- 현재 `public/images`의 이미지는 학습용 플레이스홀더 SVG입니다.
+- 실제 공개 서비스에서는 이미지/로고/상표권 라이선스를 반드시 확인하세요.

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-slate-50 text-slate-900;
+  @apply bg-slate-950 text-white;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,19 +5,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <body>
-        <header className="border-b bg-white">
-          <nav className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3 text-sm">
-            <Link href="/" className="font-semibold">
-              MemoSaaS
+        <header className="border-b border-slate-800 bg-slate-950/95 backdrop-blur">
+          <nav className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 text-sm">
+            <Link href="/" className="text-lg font-black tracking-wide text-rose-400">
+              Jordan Legacy
             </Link>
-            <div className="flex gap-4">
-              <Link href="/dashboard">대시보드</Link>
-              <Link href="/pricing">요금제</Link>
-              <Link href="/login">로그인</Link>
+            <div className="flex gap-4 text-slate-300">
+              <a href="#timeline">Timeline</a>
+              <a href="#gallery">Gallery</a>
+              <a href="#quotes">Quotes</a>
+              <a href="#board">Free Board</a>
             </div>
           </nav>
         </header>
-        <main className="mx-auto max-w-3xl px-4 py-8">{children}</main>
+        <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,52 @@
-import { CreateNoteForm } from "@/components/CreateNoteForm";
+import Image from "next/image";
+import { BoardSection } from "@/components/BoardSection";
+import { gallery, quotes, timeline } from "@/lib/mj-data";
 
 export default function HomePage() {
   return (
-    <section className="space-y-4 text-center">
-      <h1 className="text-2xl font-bold">온라인 메모 공유 SaaS</h1>
-      <p className="text-sm text-slate-600">텍스트를 저장하고 링크로 바로 공유하세요.</p>
-      <CreateNoteForm />
-    </section>
+    <div className="space-y-14">
+      <section className="rounded-3xl border border-slate-800 bg-gradient-to-r from-slate-900 to-slate-800 p-8">
+        <p className="text-sm uppercase tracking-[0.2em] text-rose-400">Jordan Legacy</p>
+        <h1 className="mt-2 text-4xl font-black">Fly Like 23</h1>
+        <p className="mt-3 max-w-2xl text-slate-300">명장면, 명언, 커리어 타임라인, 그리고 팬 자유게시판을 한곳에서 즐기는 마이클 조던 SNS형 아카이브.</p>
+      </section>
+
+      <section id="timeline" className="space-y-4">
+        <h2 className="text-2xl font-bold">Career Timeline</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {timeline.map((item) => (
+            <article key={item.year} className="rounded-xl border border-slate-700 bg-slate-900 p-4">
+              <p className="text-rose-400">{item.year}</p>
+              <h3 className="font-semibold">{item.title}</h3>
+              <p className="text-sm text-slate-300">{item.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section id="gallery" className="space-y-4">
+        <h2 className="text-2xl font-bold">Gallery</h2>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {gallery.map((image) => (
+            <figure key={image.src} className="overflow-hidden rounded-xl border border-slate-700 bg-slate-900">
+              <Image src={image.src} alt={image.alt} width={420} height={280} className="h-52 w-full object-cover" />
+            </figure>
+          ))}
+        </div>
+      </section>
+
+      <section id="quotes" className="space-y-4">
+        <h2 className="text-2xl font-bold">Quotes</h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          {quotes.map((quote) => (
+            <blockquote key={quote} className="rounded-xl border border-slate-700 bg-slate-900 p-4 text-sm text-slate-200">
+              “{quote}”
+            </blockquote>
+          ))}
+        </div>
+      </section>
+
+      <BoardSection />
+    </div>
   );
 }

--- a/components/BoardSection.tsx
+++ b/components/BoardSection.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+
+type Post = {
+  id: number;
+  nickname: string;
+  title: string;
+  content: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = "mj-fan-board-posts";
+
+export function BoardSection() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [nickname, setNickname] = useState("");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    setPosts(JSON.parse(raw));
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  }, [posts]);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!nickname.trim() || !title.trim() || !content.trim()) return;
+
+    const newPost: Post = {
+      id: Date.now(),
+      nickname: nickname.trim(),
+      title: title.trim(),
+      content: content.trim(),
+      createdAt: new Date().toLocaleString("ko-KR"),
+    };
+
+    setPosts((prev) => [newPost, ...prev]);
+    setNickname("");
+    setTitle("");
+    setContent("");
+  };
+
+  return (
+    <section id="board" className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold">Free Board</h2>
+        <p className="text-sm text-slate-400">로그인 없이 닉네임으로 자유롭게 글을 남겨보세요.</p>
+      </div>
+
+      <form onSubmit={onSubmit} className="grid gap-3 rounded-2xl border border-slate-700 bg-slate-900 p-4">
+        <input
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="닉네임 / 아이디"
+          className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+        />
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="제목"
+          className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={3}
+          placeholder="응원 메시지 또는 자유 글"
+          className="rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm"
+        />
+        <button className="rounded-md bg-rose-500 px-4 py-2 text-sm font-semibold hover:bg-rose-400">게시하기</button>
+      </form>
+
+      <div className="space-y-3">
+        {posts.length === 0 ? (
+          <p className="text-sm text-slate-400">첫 게시글을 작성해보세요.</p>
+        ) : (
+          posts.map((post) => (
+            <article key={post.id} className="rounded-xl border border-slate-700 bg-slate-900 p-4">
+              <div className="mb-2 flex items-center justify-between text-xs text-slate-400">
+                <span>@{post.nickname}</span>
+                <span>{post.createdAt}</span>
+              </div>
+              <h3 className="font-semibold">{post.title}</h3>
+              <p className="mt-1 text-sm text-slate-300">{post.content}</p>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/lib/mj-data.ts
+++ b/lib/mj-data.ts
@@ -1,0 +1,21 @@
+export const timeline = [
+  { year: '1982', title: 'NCAA 우승 & 결승 위닝샷', description: '노스캐롤라이나 대학 시절, 큰 무대에서 첫 위닝샷으로 이름을 알렸습니다.' },
+  { year: '1984', title: 'NBA 드래프트 3순위', description: '시카고 불스에 지명되며 NBA 커리어가 시작되었습니다.' },
+  { year: '1991', title: '첫 NBA 챔피언', description: '불스 왕조의 시작. 첫 파이널 우승과 파이널 MVP를 차지했습니다.' },
+  { year: '1997', title: 'Flu Game', description: '몸 상태가 좋지 않은 상황에서도 역사적인 퍼포먼스를 남겼습니다.' },
+  { year: '1998', title: 'The Last Shot', description: '유타 재즈전 결승 점프로 커리어 대표 장면을 완성했습니다.' },
+];
+
+export const quotes = [
+  'I can accept failure, everyone fails at something. But I can’t accept not trying.',
+  'Some people want it to happen, some wish it would happen, others make it happen.',
+  'Talent wins games, but teamwork and intelligence win championships.',
+];
+
+export const gallery = [
+  { src: '/images/jordan-01.svg', alt: '마이클 조던 덩크 장면 일러스트' },
+  { src: '/images/jordan-02.svg', alt: '마이클 조던 커리어 아트워크' },
+  { src: '/images/jordan-03.svg', alt: '마이클 조던 블랙 앤 화이트 장면' },
+  { src: '/images/jordan-04.svg', alt: '마이클 조던 슬램덩크 장면' },
+  { src: '/images/jordan-05.svg', alt: '마이클 조던 드림팀 아트워크' },
+];

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,23 +1,33 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
+type CookieToSet = {
+  name: string;
+  value: string;
+  options?: {
+    domain?: string;
+    expires?: Date;
+    httpOnly?: boolean;
+    maxAge?: number;
+    path?: string;
+    sameSite?: "lax" | "strict" | "none";
+    secure?: boolean;
+  };
+};
+
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options);
-          });
-        },
+  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
       },
-    }
-  );
+      setAll(cookiesToSet: CookieToSet[]) {
+        cookiesToSet.forEach(({ name, value, options }) => {
+          cookieStore.set(name, value, options);
+        });
+      },
+    },
+  });
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,3 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/images/jordan-01.svg
+++ b/public/images/jordan-01.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='520' viewBox='0 0 800 520'>
+  <defs><linearGradient id='g' x1='0' x2='1'><stop offset='0%' stop-color='#0f172a'/><stop offset='100%' stop-color='#be123c'/></linearGradient></defs>
+  <rect width='800' height='520' fill='url(#g)'/>
+  <text x='50%' y='44%' fill='#fff' font-size='64' font-family='Arial' text-anchor='middle'>MICHAEL JORDAN</text>
+  <text x='50%' y='58%' fill='#fecdd3' font-size='36' font-family='Arial' text-anchor='middle'>Legacy Scene 01</text>
+</svg>

--- a/public/images/jordan-02.svg
+++ b/public/images/jordan-02.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='520' viewBox='0 0 800 520'>
+  <defs><linearGradient id='g' x1='0' x2='1'><stop offset='0%' stop-color='#0f172a'/><stop offset='100%' stop-color='#be123c'/></linearGradient></defs>
+  <rect width='800' height='520' fill='url(#g)'/>
+  <text x='50%' y='44%' fill='#fff' font-size='64' font-family='Arial' text-anchor='middle'>MICHAEL JORDAN</text>
+  <text x='50%' y='58%' fill='#fecdd3' font-size='36' font-family='Arial' text-anchor='middle'>Legacy Scene 02</text>
+</svg>

--- a/public/images/jordan-03.svg
+++ b/public/images/jordan-03.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='520' viewBox='0 0 800 520'>
+  <defs><linearGradient id='g' x1='0' x2='1'><stop offset='0%' stop-color='#0f172a'/><stop offset='100%' stop-color='#be123c'/></linearGradient></defs>
+  <rect width='800' height='520' fill='url(#g)'/>
+  <text x='50%' y='44%' fill='#fff' font-size='64' font-family='Arial' text-anchor='middle'>MICHAEL JORDAN</text>
+  <text x='50%' y='58%' fill='#fecdd3' font-size='36' font-family='Arial' text-anchor='middle'>Legacy Scene 03</text>
+</svg>

--- a/public/images/jordan-04.svg
+++ b/public/images/jordan-04.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='520' viewBox='0 0 800 520'>
+  <defs><linearGradient id='g' x1='0' x2='1'><stop offset='0%' stop-color='#0f172a'/><stop offset='100%' stop-color='#be123c'/></linearGradient></defs>
+  <rect width='800' height='520' fill='url(#g)'/>
+  <text x='50%' y='44%' fill='#fff' font-size='64' font-family='Arial' text-anchor='middle'>MICHAEL JORDAN</text>
+  <text x='50%' y='58%' fill='#fecdd3' font-size='36' font-family='Arial' text-anchor='middle'>Legacy Scene 04</text>
+</svg>

--- a/public/images/jordan-05.svg
+++ b/public/images/jordan-05.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='800' height='520' viewBox='0 0 800 520'>
+  <defs><linearGradient id='g' x1='0' x2='1'><stop offset='0%' stop-color='#0f172a'/><stop offset='100%' stop-color='#be123c'/></linearGradient></defs>
+  <rect width='800' height='520' fill='url(#g)'/>
+  <text x='50%' y='44%' fill='#fff' font-size='64' font-family='Arial' text-anchor='middle'>MICHAEL JORDAN</text>
+  <text x='50%' y='58%' fill='#fecdd3' font-size='36' font-family='Arial' text-anchor='middle'>Legacy Scene 05</text>
+</svg>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,25 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
-    "paths": {"@/*": ["./*"]}
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "job-portal"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Repurpose the existing MemoSaaS landing into a Michael Jordan fan SNS-style learning site that showcases highlights, quotes, a gallery, and a lightweight community board.
- Provide an immediate, client-only experience where visitors can post under a nickname without auth, enabling quick local testing and portfolio demos.
- Ship placeholder assets and a dark-themed UI so the site is visually coherent while noting all media are for learning/portfolio use and must be replaced for public release.

### Description
- Reworked the homepage into a multi-section fan experience by replacing `app/page.tsx` to include a hero, `timeline`, `gallery`, `quotes`, and the `BoardSection` component.
- Added a client-side `components/BoardSection.tsx` that supports nickname/title/content posting with persistence in `localStorage` under the key `mj-fan-board-posts`.
- Introduced `lib/mj-data.ts` to centralize `timeline`, `quotes`, and `gallery` data and added placeholder SVG assets at `public/images/jordan-01.svg`...`jordan-05.svg` for the gallery.
- Updated site chrome and styling by editing `app/layout.tsx` (branding and anchor nav), `app/globals.css` (dark theme), `README.md` (project purpose), `.gitignore`, and a small comment in `next-env.d.ts`.

### Testing
- Ran `npm run lint`, but the process could not complete because Next.js launched the interactive ESLint setup prompt in this non-interactive environment, so linting did not finish.
- No other automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b84c73a0832c8091b01128938520)